### PR TITLE
QoL UI features

### DIFF
--- a/FireArrows/Items/ItemFireArrow.cs
+++ b/FireArrows/Items/ItemFireArrow.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
+using Vintagestory.API.Util;
 using Vintagestory.GameContent;
 
 namespace FireArrows.Items;
@@ -15,6 +17,7 @@ public class ItemFireArrow : ItemArrow, IIgnitable
     private bool changedState = false;
     public bool IsExtinct => isExtinct;
     public CollectibleObject? ExtinctVariant { get; private set; }
+    private WorldInteraction[] interactions = [];
     public override void OnLoaded(ICoreAPI api)
     {
         base.OnLoaded(api);
@@ -25,6 +28,35 @@ public class ItemFireArrow : ItemArrow, IIgnitable
             ExtinctVariant = api.World.GetItem(loc);
             isExtinct = Variant["state"] == "extinct";
             isLit = Variant["state"] == "lit";
+        }
+
+        if (isExtinct)
+        {
+            interactions = ObjectCacheUtil.GetOrCreate<WorldInteraction[]>(api, "firearrowInteractions", () =>
+            {
+                List<ItemStack> torchStacks = [];
+                foreach (CollectibleObject obj in api.World.Collectibles)
+                {
+                    if (obj is BlockTorch torch && torch.LastCodePart(1) == "lit")
+                    {
+                        Console.WriteLine(obj.Code);
+                        var stacks = obj.GetHandBookStacks(api as ICoreClientAPI);
+                        if (stacks != null)
+                        {
+                            torchStacks.AddRange(stacks);
+                        }
+                    }
+                }
+                
+                return [
+                    new WorldInteraction()
+                    {
+                        ActionLangCode = "firearrows:item-firearrow-hotbarhelp",
+                        MouseButton = EnumMouseButton.Right,
+                        Itemstacks = [.. torchStacks]
+                    },
+                ];
+            });
         }
     }
 
@@ -78,7 +110,23 @@ public class ItemFireArrow : ItemArrow, IIgnitable
         base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
 
         dsc.AppendLine();
-        dsc.AppendLine(Lang.Get("firearrows:item-firearrow-flavortext"));
+        if (isExtinct)
+        {
+            dsc.AppendLine(Lang.Get("firearrows:item-firearrow-instructions"));
+        }
+        else
+        {
+            dsc.AppendLine(Lang.Get("firearrows:item-firearrow-flavortext"));
+        }
+    }
+
+    public override WorldInteraction[] GetHeldInteractionHelp(ItemSlot inSlot)
+    {   
+        return
+        [
+            .. interactions,
+            .. base.GetHeldInteractionHelp(inSlot),
+        ];
     }
 
     public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handling)

--- a/FireArrows/assets/firearrows/itemtypes/firearrow.json
+++ b/FireArrows/assets/firearrows/itemtypes/firearrow.json
@@ -29,6 +29,22 @@
 			}
 		}
     },
+	"combustiblePropsbyType": {
+		"*-lit": {
+			"burnTemperature": 600,
+			"burnDuration": 8
+		},
+		"*-extinct": {
+			"burnTemperature": 600,
+			"burnDuration": 8,
+			"meltingPoint": 300,
+			"meltingDuration": 1,
+			"smeltedRatio": 1,
+			"smeltingType": "convert",
+			"smeltedStack": { "type": "item", "code": "arrow-firearrow-lit" },
+			"requiresContainer": false
+		}
+	},
 	"creativeinventory": { "general": ["*"], "items": ["*"], "tools": ["*"] },
 	"guiTransform": {
 		"translation": { "x": 1, "y": 2, "z": 0 },

--- a/FireArrows/assets/firearrows/lang/en.json
+++ b/FireArrows/assets/firearrows/lang/en.json
@@ -1,5 +1,7 @@
 {
 	"item-arrow-firearrow-lit": "Fire arrow",
 	"item-arrow-firearrow-extinct": "Fire arrow (unlit)",
-	"item-firearrow-flavortext": "Because of its weight and lack of sharpness, it might not be very useful for combat. However, its fire is very bright, so it can bring light to the dark."
+	"item-firearrow-flavortext": "Because of its weight and lack of sharpness, it might not be very useful for combat. However, its fire is very bright, so it can bring light to the dark.",
+	"item-firearrow-instructions": "Must be lit to provide light. Hold a lit torch in your left hand, then hold the arrow in your right hand, then hold right click.<br>Can also be lit the same way torches can.",
+	"item-firearrow-hotbarhelp": "Ignite"
 }

--- a/FireArrows/assets/firearrows/recipes/grid/firearrow.json
+++ b/FireArrows/assets/firearrows/recipes/grid/firearrow.json
@@ -10,5 +10,26 @@
 		"width": 3,
 		"height": 3,
 		"output": { "type": "item", "code": "firearrows:arrow-firearrow-extinct", "quantity": 1  }
+	},
+	{
+		"ingredientPattern": "G,A",
+		"ingredients": {
+			"G": { "type": "item", "code": "game:drygrass", "quantity": 2 },
+			"A": { "type": "item", "code": "game:arrow-flint" }
+		},
+		"width": 1,
+		"height": 2,
+		"output": { "type": "item", "code": "firearrows:arrow-firearrow-extinct", "quantity": 1  }
+	},
+	{
+		"ingredientPattern": "G,C,F",
+		"ingredients": {
+			"G": { "type": "item", "code": "game:drygrass", "quantity": 2 },
+			"C": { "type": "item", "code": "game:arrow-crude" },
+			"F": { "type": "item", "code": "game:feather" }
+		},
+		"width": 1,
+		"height": 3,
+		"output": { "type": "item", "code": "firearrows:arrow-firearrow-extinct", "quantity": 1  }
 	}
 ]


### PR DESCRIPTION
- Changed the unlit arrow's tooltip to contain instructions
- Added burn conversion recipe: Fire arrow (unlit) -> Fire arrow @ 300 °C
- Added several QoL recipes, you can now use crude or flint arrows to craft the unlit arrows.
- Added some held item info